### PR TITLE
Adding preview font onchange for ACF5

### DIFF
--- a/js/input.js
+++ b/js/input.js
@@ -56,7 +56,7 @@
 
 							preview_text = jQuery('#acfgfs-preview div').html();
 							font = new_font.replace( ' ', '+' );
-							container.find('.acfgfs-preview').html('<link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=' + font + '"><div style="font-family:' + new_font + '"></div>')
+							container.find('.acfgfs-preview').html('<link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=' + font + '"><div style="font-family:' + new_font + '">This is a preview of the selected font</div>')
 							jQuery('#acfgfs-preview div').html(preview_text)
 
                         }


### PR DESCRIPTION
Noticed changing fonts currently on ACF5 version doesn't show any preview text.

Here is the fix.